### PR TITLE
Manually add the missing release notes for v0.20.0

### DIFF
--- a/content/release/index.html
+++ b/content/release/index.html
@@ -48,7 +48,7 @@
     <link rel="icon" href="../../_static/logo-block.ico"/>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />
-    <link rel="next" title="SimPEG 0.19.0 Release Notes" href="0.19.0-notes.html" />
+    <link rel="next" title="SimPEG 0.20.0 Release Notes" href="0.20.0-notes.html" />
     <link rel="prev" title="SimPEG.meta.MultiprocessingRepeatedSimulation" href="../api/generated/SimPEG.meta.MultiprocessingRepeatedSimulation.html" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -487,6 +487,7 @@ document.write(`
      aria-label="Section Navigation">
   <p class="bd-links__title" role="heading" aria-level="1">Section Navigation</p>
   <div class="bd-toc-item navbar-nav"><ul class="nav bd-sidenav">
+<li class="toctree-l1"><a class="reference internal" href="0.20.0-notes.html">0.20.0</a></li>
 <li class="toctree-l1"><a class="reference internal" href="0.19.0-notes.html">0.19.0</a></li>
 <li class="toctree-l1"><a class="reference internal" href="0.18.1-notes.html">0.18.1</a></li>
 <li class="toctree-l1"><a class="reference internal" href="0.18.0-notes.html">0.18.0</a></li>
@@ -557,6 +558,12 @@ document.write(`
 <h1>Release Notes<a class="headerlink" href="#release-notes" title="Permalink to this heading">#</a></h1>
 <div class="toctree-wrapper compound">
 <ul>
+<li class="toctree-l1"><a class="reference internal" href="0.20.0-notes.html">0.20.0</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="0.20.0-notes.html#updates">Updates</a></li>
+<li class="toctree-l2"><a class="reference internal" href="0.20.0-notes.html#contributors">Contributors</a></li>
+<li class="toctree-l2"><a class="reference internal" href="0.20.0-notes.html#pull-requests">Pull requests</a></li>
+</ul>
+</li>
 <li class="toctree-l1"><a class="reference internal" href="0.19.0-notes.html">0.19.0</a><ul>
 <li class="toctree-l2"><a class="reference internal" href="0.19.0-notes.html#updates">Updates</a></li>
 <li class="toctree-l2"><a class="reference internal" href="0.19.0-notes.html#contributors">Contributors</a></li>
@@ -674,11 +681,11 @@ document.write(`
       </div>
     </a>
     <a class="right-next"
-       href="0.19.0-notes.html"
+       href="0.20.0-notes.html"
        title="next page">
       <div class="prev-next-info">
         <p class="prev-next-subtitle">next</p>
-        <p class="prev-next-title">SimPEG 0.19.0 Release Notes</p>
+        <p class="prev-next-title">SimPEG 0.20.0 Release Notes</p>
       </div>
       <i class="fa-solid fa-angle-right"></i>
     </a>


### PR DESCRIPTION
Temporarily fix the missing release notes for the latest release. The release notes for v0.20.0 were added to the TOC in
https://github.com/simpeg/simpeg/pull/1277. This PR is only meant to make them available until we deploy a new build of the docs.
